### PR TITLE
Add context manager method with patched builtins

### DIFF
--- a/console_testing/MockConsole.py
+++ b/console_testing/MockConsole.py
@@ -1,3 +1,6 @@
+from contextlib import contextmanager
+from unittest.mock import patch
+
 from console_testing.ConsoleExpectation import ConsoleExpectation
 from console_testing.Console import Console
 
@@ -27,3 +30,9 @@ class MockConsole(Console):
         expectation_text = 'expectation' if len(self.expectations) == 1 else 'expectations'
 
         assert len(self.expectations) == 0, f"All the message expectations were not met. Missing {len(self.expectations)} {expectation_text}."
+
+    @contextmanager
+    def all_expectations_met(self):
+        with patch.multiple('builtins', print=self.print, input=self.ask):
+            yield self
+        self.assert_expectations_met()

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -1,0 +1,69 @@
+import pytest
+
+from console_testing import MockConsole
+
+
+@pytest.fixture
+def mock_console():
+    console = MockConsole()
+    console.expect_question("What's your name? ", "Bob")
+    console.expect_message("Hello, Bob")
+    return console
+
+
+def test_context_manager_passes_if_all_expectations_met(mock_console):
+    def script():
+        name = input("What's your name? ")
+        print(f"Hello, {name}")
+
+    with mock_console.all_expectations_met():
+        script()
+
+
+def test_context_manager_fails_if_unexpected_message(mock_console):
+    def script():
+        name = input("What's your name? ")
+        print(f"Welcome, {name}")  # unexpected message
+
+    with pytest.raises(AssertionError, match=r"got 'Welcome, Bob' instead"):
+        with mock_console.all_expectations_met():
+            script()
+
+
+def test_context_manager_fails_if_unexpected_question(mock_console):
+    def script():
+        name = input("What is your name? ")  # unexpected question
+        print(f"Hello, {name}")
+
+    with pytest.raises(AssertionError, match=r"got 'What is your name\? ' instead"):
+        with mock_console.all_expectations_met():
+            script()
+
+
+def test_context_manager_fails_if_unexpected_message_type(mock_console):
+    def script():
+        print("This is a message.")  # unexpected message type
+
+    with pytest.raises(AssertionError, match=r"got a message instead"):
+        with mock_console.all_expectations_met():
+            script()
+
+
+def test_context_manager_fails_if_actual_more_than_expected(mock_console):
+    def script():
+        name = input("What's your name? ")
+        print(f"Hello, {name}")
+        print("Additional message.")
+
+    with pytest.raises(AssertionError, match=r"expectations list is empty"):
+        with mock_console.all_expectations_met():
+            script()
+
+
+def test_context_manager_fails_if_actual_less_than_expected(mock_console):
+    def script():
+        name = input("What's your name? ")
+
+    with pytest.raises(AssertionError, match=r"Missing 1 expectation"):
+        with mock_console.all_expectations_met():
+            script()


### PR DESCRIPTION
Add a method `all_expectations_met` that temporarily patches `print` and `input` and can be used as a context manager in tests.