### PR TITLE
Populate MockConsole from an iterable

### DIFF
--- a/console_testing/MockConsole.py
+++ b/console_testing/MockConsole.py
@@ -36,3 +36,13 @@ class MockConsole(Console):
         with patch.multiple('builtins', print=self.print, input=self.ask):
             yield self
         self.assert_expectations_met()
+
+    @classmethod
+    def from_iterable(cls, iterable):
+        console = cls()
+        for item in iterable:
+            if len(item) == 1:
+                console.expect_message(*item)
+            elif len(item) == 2:
+                console.expect_question(*item)
+        return console

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -5,10 +5,7 @@ from console_testing import MockConsole
 
 @pytest.fixture
 def mock_console():
-    console = MockConsole()
-    console.expect_question("What's your name? ", "Bob")
-    console.expect_message("Hello, Bob")
-    return console
+    return MockConsole.from_iterable([["What's your name? ", "Bob"], ["Hello, Bob"]])
 
 
 def test_context_manager_passes_if_all_expectations_met(mock_console):

--- a/tests/test_external_scripts.py
+++ b/tests/test_external_scripts.py
@@ -18,14 +18,15 @@ def scripts_in_path():
 
 @pytest.fixture
 def mock_console():
-    console = MockConsole()
-    console.expect_question("Your name: ", "George")
-    console.expect_message("Hello, George.")
-    console.expect_question("What is 2**10? ", "64")
-    console.expect_message("wrong")
-    console.expect_question("What is 2**10? ", "1024")
-    console.expect_message("correct")
-    return console
+    expectations = [
+        ["Your name: ", "George"],
+        ["Hello, George."],
+        ["What is 2**10? ", "64"],
+        ["wrong"],
+        ["What is 2**10? ", "1024"],
+        ["correct"],
+    ]
+    return MockConsole.from_iterable(expectations)
 
 
 def test_simple_script(scripts_in_path, mock_console):

--- a/tests/test_from_iterable.py
+++ b/tests/test_from_iterable.py
@@ -1,0 +1,12 @@
+from console_testing import MockConsole
+
+
+def test_from_iterable():
+    expectations_list = [
+        ["What's the time? ", "2 p.m."],
+        ["Good afternoon!"],
+    ]
+    console = MockConsole.from_iterable(expectations_list)
+    with console.all_expectations_met():
+        answer = input("What's the time? ")
+        print("Good morning!" if "a.m." in answer else "Good afternoon!")


### PR DESCRIPTION
Hi Duilio,
I played with the code again and added a `from_iterable` factory method that allows to populate a new MockConsole instance from a nested list of messages and question-answer pairs. Please check it out.

For example, the following:

```python
console = MockConsole()
console.expect_question("Your name: ", "George")
console.expect_message("Hello, George.")
console.expect_question("What is 2**10? ", "64")
console.expect_message("wrong")
console.expect_question("What is 2**10? ", "1024")
console.expect_message("correct")
```

can be replaced with the less verbose

```python
expectations = [
    ["Your name: ", "George"],
    ["Hello, George."],
    ["What is 2**10? ", "64"],
    ["wrong"],
    ["What is 2**10? ", "1024"],
    ["correct"],
]
console = MockConsole.from_iterable(expectations)
```